### PR TITLE
Added libtool, staticlibs to options array.

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -74,7 +74,7 @@ pkgver=${_year}.${_icc_ver}.${_v_a}.${_v_b}
 
 _dir_nr='3447'
 
-options=(strip)
+options=(strip libtool staticlibs)
 
 
 if $_amd_64 ; then


### PR DESCRIPTION
Recently, an update to /etc/makepkg.conf changed the options defaults (^OPTIONS=...) to have !libtool !staticlibs.  This causes libimf, libdecimal, libsvml, libipgo, etc. default libraries that ICC/IFC link into programs built by them to be stripped from the pkg by makepkg.  This causes a linker error when trying to compile anything (without -nodefaultlibs), even "helloworld.c".  

This commit fixes that by specifying staticlibs and libtool in the options array.
