### PR TITLE
Updated to 2013_sp1_update1.

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -47,15 +47,15 @@ _remove_docs=true
 ########################################
 ########################################
 # set to true if you want to remove the static objects form the libs .
-_remove_static_objects_mkl=true
-_remove_static_objects_ipp=true
+_remove_static_objects_mkl=false
+_remove_static_objects_ipp=false
 ########################################
 
 _year='2013'
-_v_a='0'
-_v_b='080' 
+_v_a='1'
+_v_b='106' 
 
-_update=''
+_update='update1'
 
 pkgrel=1
 
@@ -63,16 +63,16 @@ _sp='sp1'
 
 _icc_ver='14.0'
 _ipp_ver='8.0.1'
-_mkl_ver='11.1.0'
-_openmp_ver='14.0.0'
-_sourcechecker_ver='14.0.0'
+_mkl_ver='11.1.1'
+_openmp_ver='14.0.1'
+_sourcechecker_ver='14.0.1'
 
-_tbb_ver='4.1.4'
+_tbb_ver='4.2.1'
 
 
 pkgver=${_year}.${_icc_ver}.${_v_a}.${_v_b}
 
-_dir_nr='3447'
+_dir_nr='3644'
 
 options=(strip libtool staticlibs)
 
@@ -89,7 +89,11 @@ arch=('i686' 'x86_64')
 license=('custom')
 makedepends=('libarchive' 'sed' 'gzip')
 
-source=('intel_compilers.sh' 
+_parallel_studio_xe_dir="parallel_studio_xe${_year:+_${_year}}${_sp:+_${_sp}}${_update:+_${_update}}"
+
+source=(
+    "http://registrationcenter-download.intel.com/akdlm/irc_nas/${_dir_nr}/${_parallel_studio_xe_dir}.tgz"
+    'intel_compilers.sh'
 	'intel-composer.install'
 	'intel-compiler-base.conf' 
 	'intel-fortran.conf'
@@ -105,10 +109,10 @@ source=('intel_compilers.sh'
 	'EULA.txt'
 	)
 
-sha256sums=( 
-	'ba65fdf7afbac0276a948ef8d4e1578297a0115548d5f3465c7ed4012030f696' # parralel studio main pkg
+sha256sums=(
+    '5d0147c6907ed7950d7f14b615785f5e3c7977c62368f4a8ec7b06be758d614a' # parallel_studio_xe_2013_sp1_update1.tgz
 	'338041f924d8f3ac31d349bca57f8ab66f094a5bb53d4f821f48fa710a112111' # intel_compilers.sh
-	'b7e1a3849c62f293245221d7ab5ee35c0e737b90b3eb4ae83c1eb41023d4e3ec' # intel-composer.install
+	'3f96dec03111e69d16bb363acf4d0570e8a9526c09e5e542a7558f1b26d043ef' # intel-composer.install
 	'31ac4d0f30a93fe6393f48cb13761d7d1ce9719708c76a377193d96416bed884' # intel-compiler-base.conf
 	'c165386ba33b25453d4f5486b7fefcdba7d31e156ad280cbdfa13ed924b01bef' # intel-fortran.conf
 	'99cc9683cc75934cc21bb5a09f6ad83365ee48712719bfd914de9444695eed13' # intel-openmp.conf
@@ -131,21 +135,14 @@ if [ "$CARCH" = "i686" ]; then
 
     _not_arch='intel64'
     _not_arch2='x86_64'
-
-    #sha256sums=( 'ba65fdf7afbac0276a948ef8d4e1578297a0115548d5f3465c7ed4012030f696' ${sha256sums[@]} )
 else
     _i_arch='intel64' 
     _i_arch2='x86_64'
 
     _not_arch='ia32' 
     _not_arch2='i486'
-    #sha256sums=('ba65fdf7afbac0276a948ef8d4e1578297a0115548d5f3465c7ed4012030f696' ${sha256sums[@]} )
 fi
 
- _parallel_studio_xe_dir="parallel_studio_xe_${_year}_${_sp}"
-
-         
-source=("http://registrationcenter-download.intel.com/akdlm/irc_nas/${_dir_nr}/${_parallel_studio_xe_dir}.tgz" ${source[@]})
 
 extract_rpms() {
   cd $2
@@ -156,13 +153,9 @@ extract_rpms() {
 }
 
 set_build_vars() {
-
   _pkg_ver=${_year}.${_icc_ver}.${_v_a}.${_v_b}
-
   _composer_xe_dir="composer_xe_${_year}_${_sp}.${_v_a}.${_v_b}"
-  _parallel_studio_xe_dir="parallel_studio_xe_${_year}_${_sp}"
   rpm_dir=${srcdir}/${_parallel_studio_xe_dir}/rpm
-
   xe_build_dir=${srcdir}/cxe_build
   base_dir=${srcdir}/..
   _man_dir=${xe_build_dir}/usr/share/man/man1
@@ -244,19 +237,22 @@ build() {
 	  _cnt=$(($_cnt+1))
 	done
 
-	if [[ ! -f "${_lic_file[0]}" ]]; then
-	  echo -e ""
-	  echo -e "-----------------------------------------------------------------------------------"
-	  echo -e "\e[1mERROR:\e[0m license file not foud!"
-	  echo -e "To continue this procedure you must obtain an original license file from Intel"
-	  echo -e "that must be copied in the PKGBUILD directory"
-	  echo -e "visit:  http://software.intel.com/en-us/articles/non-commercial-software-download/"
-	  echo -e "-----------------------------------------------------------------------------------"
-	  return 1 ;
-	fi
-
+    echo -e ""
+	echo -e "-----------------------------------------------------------------------------------"
 	mkdir -p ${xe_build_dir}/opt/intel/licenses
-	cp ${base_dir}/*.lic ${xe_build_dir}/opt/intel/licenses
+    if [ -f "${_lic_file[0]}" ]; then
+	    cp ${base_dir}/*.lic ${xe_build_dir}/opt/intel/licenses
+	    echo -e "\e[1mFound license files in ${base_dir}."
+        echo -e "These will be installed into /opt/intel/licenses ...\e[0m"
+    else
+	    echo -e "\e[1mNo license files found in ${base_dir}."
+        echo -e "Remember to place license files in one of these locations:"
+        echo -e "    /opt/intel/licenses"
+        echo -e "    ~/intel/licenses"
+        echo -e "Or the compiler will not work!\e[0m"
+    fi
+	echo -e "-----------------------------------------------------------------------------------"
+    echo -e ""
 
 	cp ${srcdir}/${_parallel_studio_xe_dir}/license.txt ${xe_build_dir}/opt/intel/license.txt
 	
@@ -280,8 +276,9 @@ build() {
 	echo -e ""
 	echo -e ""
 	echo -e "-----------------------------------------------------------------------------------"
-	echo -e " \e[1m\e[5mATTENTION: \e[0m \e[1m\e[31mThis PKGBUILD don't work with yaourt! \e[0m "
-	echo -e " You must use the makepkg command for building this package"
+	echo -e " \e[1m\e[5mATTENTION: \e[0m \e[1m\e[31mThis PKGBUILD works with yaourt, "
+    echo -e "but consumes a lot of RAM! \e[0m "
+	echo -e " Using the makepkg command for building this package is recommended."
 	echo -e "-----------------------------------------------------------------------------------"
 	echo -e ""
 	echo -e ""
@@ -437,9 +434,9 @@ package_intel-fortran-compiler() {
 	rm *.csh
 
 	#rm ${xe_build_dir}/opt/intel/${_composer_xe_dir}/Documentation/en_US/gs_resources/intel_f_logo.gif
-	#rm ${xe_build_dir}/opt/intel/${_composer_xe_dir}/compiler/lib/${_i_arch}/locale/ja_JP/diagspt.cat
-	#rm ${xe_build_dir}/opt/intel/${_composer_xe_dir}/compiler/lib/${_i_arch}/locale/ja_JP/flexnet.cat
-	#rm ${xe_build_dir}/opt/intel/${_composer_xe_dir}/compiler/lib/${_i_arch}/locale/ja_JP/helpxi.cat
+	rm ${xe_build_dir}/opt/intel/${_composer_xe_dir}/compiler/lib/${_i_arch}/locale/ja_JP/diagspt.cat
+	rm ${xe_build_dir}/opt/intel/${_composer_xe_dir}/compiler/lib/${_i_arch}/locale/ja_JP/flexnet.cat
+	rm ${xe_build_dir}/opt/intel/${_composer_xe_dir}/compiler/lib/${_i_arch}/locale/ja_JP/helpxi.cat
 
 	if $_remove_docs ; then
 	  echo -e " # intel-fortran-compiler: Remove documentation"

--- a/intel-composer.install
+++ b/intel-composer.install
@@ -1,6 +1,9 @@
 
 ## arg 1:  the new package version
 post_install() {
+   echo "Intel-Compiler-Base: Please remember to put your Intel license file in"
+   echo "/opt/intel/licenses/ (system-wide) or in ~/intel/licenses/ (user-specific)"
+
    ldconfig ;
 }
 


### PR DESCRIPTION
Also removed requirement to have a license file in ${basedir}, since users may
wish to place their license files in ~/intel/licenses, or manage licenses
out-of-package.  This also means the package can be installed with yaourt now:

```
yaourt -S intel-parallel-studio-xe
```

HOWEVER, if using yaourt, remember to set your TMPDIR to something other than
/tmp since the package downloaded consumes 3.2GB of space.
