### PR TITLE
Upgrade from "update 2" to "update 3"

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -55,10 +55,10 @@ _remove_static_objects_ipp=true
 ########################################
 
 _year='2015'
-_v_a='2'
-_v_b='164' 
+_v_a='3'
+_v_b='187'
 
-_update='update2'
+_update='update3'
 
 pkgrel=1
 
@@ -69,7 +69,7 @@ _ipp_ver='8.2.1'
 _mkl_ver='11.2.2'
 _openmp_ver='15.0.1'
 _sourcechecker_ver='15.0.2'
-_vtune_ver='2.0.393444'
+_vtune_ver='3.0.403110'
 _advisor_ver='1.10.380555'
 _inspector_ver='1.2.379161'
 
@@ -78,7 +78,7 @@ _tbb_ver='4.3.0'
 
 pkgver=${_year}.${_icc_ver}.${_v_a}.${_v_b}
 
-_dir_nr='5207'
+_dir_nr='7538'
 
 options=(strip libtool staticlibs)
 
@@ -123,7 +123,7 @@ source=(
 
 
 sha256sums=(
-	'8cbde4d4fb3bbfcc5096d5d924953121ca84e9a9bee7b00dfd07c029c1a89943' # parallel_studio_xe_2015_update2.tgz
+	'ab7169989c87bbb0fe66221cb7eb3a26b17c8b9ceff38f1926e5607834306896' # parallel_studio_xe_2015_update3.tgz
 	'338041f924d8f3ac31d349bca57f8ab66f094a5bb53d4f821f48fa710a112111' # intel_compilers.sh
 	'7da22140b9d8277d06d88f6bd37cb77ed17bc87d4f7ec5958587416639955991' # intel_vtune-amplifier-xe.sh
 	'292a9eea2c9a836ee9dc0d4ff28fc741d5548a3182e4f75aec7b93e1dd7b4f21' # intel_advisor-xe.sh
@@ -137,7 +137,7 @@ sha256sums=(
 	'aee2ae7f87f12f4af38d52423b40d547fd5bbe77e18694b9847e9f2a96d33c6e' # intel-tbb.conf
 	'5e68c529c65cac54218026c869e54b2ddb268179725fc1e6b56d920470dad999' # intel-mkl.sh
 	'11398c0ae2e2011902b1d6356d916d41bb8b54d39d090c6c83630f4b0e84e93a' # intel-mkl.install
-        'e515cb28bf40cdb0db818db6a2688a0028575153a1b9d5acfb0bc5f13fe45722' # intel-mkl-th.conf
+	'e515cb28bf40cdb0db818db6a2688a0028575153a1b9d5acfb0bc5f13fe45722' # intel-mkl-th.conf
 	'8c6a1f7b1b12d498e68b3085d8b2fcd050505209b7c0f2b870ba5f65ee135a90' # intel-tbb.install
 	'228ac25e147adb9b872e1a562e522d2fd48809ccae89b765112009896a6d55a5' # EULA.txt
 	)


### PR DESCRIPTION
Upgraded hashes and version to "update 3". So far, the installation works.

I noticed that after the installation, there is a dead link in /opt/intel/debugger_lib:

$ file /opt/intel/debugger_lib
/opt/intel/debugger_lib: broken symbolic link to ./composerxe/debugger/lib/intel64

$ pacman -Qo /opt/intel/debugger_lib
/opt/intel/debugger_lib is owned by intel-compiler-base 2015.15.0.2.3.187-1
